### PR TITLE
update `riscv` dependency to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-riscv = "0.6.0"
+riscv = "0.7.0"
 vcell = "0.1.3"


### PR DESCRIPTION
Fix "incompatible hard-float ABI error".